### PR TITLE
Fix error when parsing trailing space characters

### DIFF
--- a/tei/client.go
+++ b/tei/client.go
@@ -107,8 +107,8 @@ func (c *Client) sendCommand(cmd string, expect string) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		line = line[:len(line)-1]
-		words := strings.Split(line, " ")
+		line = strings.TrimSpace(line)
+		words := strings.Fields(line)
 		if words[0] == expect {
 			return words, nil
 		}

--- a/tei/server.go
+++ b/tei/server.go
@@ -43,11 +43,11 @@ func (e *Engine) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		line = line[:len(line)-1]
+		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
-		words := strings.Split(line, " ")
+		words := strings.Fields(line)
 		switch words[0] {
 		case "tei":
 			fmt.Fprintln(e.out, "id name Taktician")


### PR DESCRIPTION
I had some issues with the tei module rejecting messages such as `position startpos moves ` (note the trailing whitespace). This PR uses strings.TrimSpace() and strings.Fields() in the input parser, to make it more robust to stupid input with trailing/consecutive whitespaces.