### PR TITLE
Update time budget calculation to avoid using the entire increment.

### DIFF
--- a/tei/server.go
+++ b/tei/server.go
@@ -139,7 +139,7 @@ func parsePosition(size int, words []string) (*tak.Position, error) {
 func calcBudget(movetime time.Duration, gametime time.Duration, inc time.Duration) time.Duration {
 	var budget time.Duration
 	if gametime != 0 {
-		budget = gametime/10 + inc
+		budget = (gametime + inc) / 10
 	}
 	if movetime > 0 && (budget == 0 || movetime < budget) {
 		budget = movetime


### PR DESCRIPTION
Tako would sometimes lose on time when increment ~= time left, because of this behavior. Example run in tei mode: 

````
> teinewgame 5
> position startpos
> go wtime 3000 winc 3000 btime 3000 binc 3000
< info depth 7 time 3300 nodes 124247 score cp 390 pv a1 a5 c3 Cc4 c2 c4- b2
< bestmove a1
````

It takes 3300ms to respond, but only had 3000 on the clock, causing a loss on time. This example is contrived, but because Taktician would always use *at least* its entire increment on every move, this situation would inevitably occur in a very long game.