### PR TITLE
Correctly parse PTNs with optional move annotations such as '?' or '*'

### DIFF
--- a/ptn/move.go
+++ b/ptn/move.go
@@ -2,9 +2,9 @@ package ptn
 
 import (
 	"errors"
-	"regexp"
-
 	"github.com/nelhage/taktician/tak"
+	"regexp"
+	"strings"
 )
 
 var moveRE = regexp.MustCompile(
@@ -56,7 +56,7 @@ func ParseMove(move string) (tak.Move, error) {
 	} else {
 		return tak.Move{}, errors.New("illegal move")
 	}
-	if i == len(move) {
+	if i == len(move) || strings.ContainsRune("!?*'", rune(move[i])) {
 		if stack != 0 {
 			return tak.Move{}, errors.New("illegal move")
 		}
@@ -82,9 +82,15 @@ func ParseMove(move string) (tak.Move, error) {
 	var slides []int
 	for ; i != len(move); i++ {
 		d := move[i]
-		slides = append(slides, int(d-'0'))
-		j++
-		stack -= int(d - '0')
+		if d >= '1' && d <= '8' {
+			slides = append(slides, int(d-'0'))
+			j++
+			stack -= int(d - '0')
+		} else if strings.ContainsRune("!?*'", rune(d)) {
+			break
+		} else {
+			return tak.Move{}, errors.New("malformed move: bad count " + string(d))
+		}
 	}
 	if stack > 0 {
 		slides = append(slides, stack)

--- a/ptn/move_test.go
+++ b/ptn/move_test.go
@@ -62,6 +62,36 @@ func TestParseMove(t *testing.T) {
 			"5d4-221",
 			"5d4-221",
 		},
+		{
+			"a1?",
+			tak.Move{X: 0, Y: 0, Type: tak.PlaceFlat},
+			"a1",
+			"Fa1",
+		},
+		{
+			"Ch7!",
+			tak.Move{X: 7, Y: 6, Type: tak.PlaceCapstone},
+			"Ch7",
+			"Ch7",
+		},
+		{
+			"b1>*'",
+			tak.Move{X: 1, Y: 0, Type: tak.SlideRight, Slides: tak.MkSlides(1)},
+			"b1>",
+			"1b1>1",
+		},
+		{
+			"2a2<*",
+			tak.Move{X: 0, Y: 1, Type: tak.SlideLeft, Slides: tak.MkSlides(2)},
+			"2a2<",
+			"2a2<2",
+		},
+		{
+			"3a1+111''!",
+			tak.Move{X: 0, Y: 0, Type: tak.SlideUp, Slides: tak.MkSlides(1, 1, 1)},
+			"3a1+111",
+			"3a1+111",
+		},
 	}
 	for _, tc := range cases {
 		get, err := ParseMove(tc.in)


### PR DESCRIPTION
The [PTN spec](https://ustak.org/portable-tak-notation/) allows moves to have optional annotations (or "Informational Marks") to signify flattening walls, creating a tak threat, and others. Tako can't parse PTNs that use these at the moment, particularly files generated by ptn ninja, since it automatically adds the `*` annotations. This PR makes the parser aware of them, so that it correctly ignores them. 

Example game: https://www.playtak.com/games/404864/ninjaviewer. You have to click to the end of the game for the annotation to be added. I tried with some more pathological examples, and it seems to work correctly with this fix. 