### PR TITLE
Increase the value of our captives under flatstones and capstones

### DIFF
--- a/ai/evaluate.go
+++ b/ai/evaluate.go
@@ -74,13 +74,13 @@ var defaultWeights = Weights{
 	HardTopCap:  100,
 	CapMobility: 10,
 
-	FlatCaptives_Hard: 200,
+	FlatCaptives_Hard: 300,
 	FlatCaptives_Soft: -200,
 
 	StandingCaptives_Hard: 300,
 	StandingCaptives_Soft: -100,
 
-	CapstoneCaptives_Hard: 250,
+	CapstoneCaptives_Hard: 350,
 	CapstoneCaptives_Soft: -100,
 
 	Groups_3: 100,


### PR DESCRIPTION
I've noticed that Tako seems to undervalue captives a bit, and will often allow its opponents get large and powerful stacks for no good reason. I've experimented with a few tweaks to the values, and this seems to work well. I ran two 2000-game matches with Racetrack on different hardware and time controls to verify an elo gain.

**CPU:** i5-4690K
**Book:** 6s_4ply_balanced_openings.txt
**Time control:** 10+0.1
**Result:** +1114-791=95. 794 white wins, 1111 black wins.
58.1% score overall, +57 elo

**CPU:** i7-8550U (hyperthreading used)
**Book:** 6s_4ply_balanced_openings.txt
**Time control:** 120+1.2
**Result:** +995-842=163. 777 white wins, 1060 black wins.
53.8% score overall, +26 elo

It's a bit worrying that the elo gain was so much lower on the longer time controls. I can't really explain it, apart from being a large statistical fluke.

Anyway, the fact that such a big elo boost was available from a simple parameter tweak, suggests that Tako could gain a lot from some kind of automated parameter tuning. If you're interested, I would suggest something like [Stockfish's tuning method](http://www.talkchess.com/forum3/viewtopic.php?start=0&t=40662), since it's easy to implement yet extremely flexible, and has been proven to work well in practice. 